### PR TITLE
Event Metadata API and specification 

### DIFF
--- a/messaging/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Event.java
+++ b/messaging/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Event.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.messaging;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An abstract event envelope, modeled after the
+ * <a href="https://github.com/cloudevents/spec/blob/master/spec.md">CNCF CloudEvent spec</a>.
+ *
+ */
+public interface Event<T> extends Message<T> {
+    /**
+     * Type of occurrence which has happened. Often this property is used for routing, observability, policy enforcement, etc.
+     */
+    String getEventType();
+
+    /**
+     * The version of the CloudEvents specification which the event uses. This enables the interpretation of the context.
+     */
+    String getCloudEventsVersion();
+
+    /**
+     * This describes the event producer. Often this will include information such as the type of the event source,
+     * the organization publishing the event, and some unique identifiers. The exact syntax and semantics behind the data
+     * encoded in the URI is event producer defined.
+     */
+    URI getSource();
+
+    /**
+     * ID of the event. The semantics of this string are explicitly undefined to ease the implementation of producers.
+     * Enables deduplication.
+     */
+    String getEventID();
+
+    /**
+     * The version of the eventType. This enables the interpretation of data by eventual consumers, requires the
+     * consumer to be knowledgeable about the producer.
+     */
+    Optional<String> getEventTypeVersion();
+    /**
+     * Timestamp of when the event happened.
+     */
+    Optional<ZonedDateTime> getEventTime();
+
+    /**
+     * A link to the schema that the data attribute adheres to.
+     */
+    Optional<URI> getSchemaURL();
+
+    /**
+     * Describe the data encoding format
+     */
+    Optional<String> getContentType();
+
+    /**
+     * This is for additional metadata and this does not have a mandated structure. This enables a place for custom
+     * fields a producer or middleware might want to include and provides a place to test metadata before
+     * adding them to the CloudEvents specification.
+     */
+    Optional<Map<?, ?>> getExtensions();
+}

--- a/messaging/spec/src/main/asciidoc/architecture.asciidoc
+++ b/messaging/spec/src/main/asciidoc/architecture.asciidoc
@@ -88,6 +88,41 @@ public CompletionStage<OutgoingMessage> processMessage(IncomingMessage msg) {
 
 Simple methods are only supported for `@Incoming` annotated methods, if there is only an `@Outgoing` annotation on the method, this is a definition error. If the method is not `@Outgoing` annotated, then the returned value is ignored - however, note that for asynchronous methods, the returned `CompletionStage` is still important for determining when message processing has completed successfully, for the purposes of message acknowledgement. When there is no `@Outgoing` annotation, `void` may also be returned.
 
+===== Event metadata
+
+The `Event` interface is an abstraction of the raw `Message` type. The `Event` contains a set of attributes, providing enriched metadata about the actual event, including the optional payload.
+
+The following example show a few custom, domain specific _events_:
+
+[source, java]
+----
+public interface DoorEvent {}
+
+@Value
+public class DoorOpened implements DoorEvent {}
+
+@Value
+public class PersonEntered implements DoorEvent {
+  public final String personId;
+}
+----
+
+The generic `DoorEvent` and the more specific `DoorOpened` event type would be representation an `Event` implementation containing no payload, while the `PersonEntered` event type would have an actual payload.
+
+Now, these custom evens could be used by an application in combination with `@Incoming` and `@Outcoming` annotations on a method:
+
+[source, java]
+----
+@Incoming
+@Outgoing
+public Event<SomeAnalyticsEvent> processEventType(Event<PersonEntered> evt) {
+  return runAnalytics(evt);
+}
+----
+
+It is modeled after the link:https://github.com/cloudevents/spec[CloudEvents Specification]
+
+
 ===== Reactive streams
 
 For more power, developers may use Reactive Streams shapes. Reactive Streams shaped methods accept no parameters, and return one of the following:


### PR DESCRIPTION
Adding Event interface, modeled after the abstract CloudEvents spec, being an envelope for events in the reactive messaging spec 

**DO NOT YET MERGE**  this needs to be rebased after https://github.com/eclipse/microprofile-reactive/pull/11 goes in