### PR TITLE
Added more TCK tests

### DIFF
--- a/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/IncomingOutgingCompletionStageMethodVerification.java
+++ b/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/IncomingOutgingCompletionStageMethodVerification.java
@@ -1,0 +1,399 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.messaging.tck;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.tck.container.ContainerPuppet;
+import org.eclipse.microprofile.reactive.messaging.tck.container.MockPayload;
+import org.eclipse.microprofile.reactive.messaging.tck.container.MockedReceiver;
+import org.eclipse.microprofile.reactive.messaging.tck.container.QuietRuntimeException;
+import org.eclipse.microprofile.reactive.messaging.tck.container.TckDeploymentUtils;
+import org.eclipse.microprofile.reactive.messaging.tck.container.TestEnvironment;
+import org.eclipse.microprofile.reactive.messaging.tck.container.Topics;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.testng.annotations.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.eclipse.microprofile.reactive.messaging.tck.container.WaitAssert.waitUntil;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Provides tests for methods of the shape:
+ *
+ * <pre>
+ * &#064;Incoming
+ * &#064;Outgoing
+ * public CompletionStage&gt;SomeMessage&lt; handle(SomeMessage message) {
+ *   ...
+ * }
+ * </pre>
+ */
+@Test(groups = {"all", "incoming", "outgoing"})
+public class IncomingOutgingCompletionStageMethodVerification extends Arquillian {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return TckDeploymentUtils.createDeployment(Bean.class);
+    }
+
+    private static final String SIMPLE_IN = "simple-in";
+    private static final String SIMPLE_OUT = "simple-out";
+    private static final String NON_PARALLEL_IN = "non-parallel-in";
+    private static final String NON_PARALLEL_OUT = "non-parallel-out";
+    private static final String SYNC_FAILING_IN = "sync-failing-in";
+    private static final String SYNC_FAILING_OUT = "sync-failing-out";
+    private static final String ASYNC_FAILING_IN = "async-failing-in";
+    private static final String ASYNC_FAILING_OUT = "async-failing-out";
+    private static final String WRAPPED_MESSAGE_IN = "wrapped-message-in";
+    private static final String WRAPPED_MESSAGE_OUT = "wrapped-message-out";
+    private static final String OUTGOING_WRAPPED_IN = "outgoing-wrapped-in";
+    private static final String OUTGOING_WRAPPED_OUT = "outgoing-wrapped-out";
+    private static final String INCOMING_OUTGOING_WRAPPED_IN = "incoming-outgoing-wrapped-in";
+    private static final String INCOMING_OUTGOING_WRAPPED_OUT = "incoming-outgoing-wrapped-out";
+
+    @Topics
+    public static String[] topics() {
+        return new String[]{SIMPLE_IN, SIMPLE_OUT, NON_PARALLEL_IN, NON_PARALLEL_OUT, SYNC_FAILING_IN, SYNC_FAILING_OUT,
+            ASYNC_FAILING_IN, ASYNC_FAILING_OUT, WRAPPED_MESSAGE_IN, WRAPPED_MESSAGE_OUT, OUTGOING_WRAPPED_IN,
+            OUTGOING_WRAPPED_OUT, INCOMING_OUTGOING_WRAPPED_IN, INCOMING_OUTGOING_WRAPPED_OUT
+        };
+    }
+
+    @ArquillianResource
+    private ContainerPuppet puppet;
+    @ArquillianResource
+    private TestEnvironment environment;
+
+    @Inject
+    private TckMessagingManager manager;
+    @Inject
+    private Bean bean;
+
+
+    @ApplicationScoped
+    public static class Bean {
+
+        @Inject
+        private TckMessagingManager manager;
+
+        @Incoming(topic = SIMPLE_IN)
+        @Outgoing(topic = SIMPLE_OUT)
+        public CompletionStage<MockPayload> handleVoidMethod(MockPayload payload) {
+            manager.getReceiver(SIMPLE_IN).receiveMessage(payload);
+            return CompletableFuture.completedFuture(payload.transform());
+        }
+
+        private final Deque<CompletableFuture<MockPayload>> futures = new ArrayDeque<>();
+
+        public Deque<CompletableFuture<MockPayload>> getFutures() {
+            return futures;
+        }
+
+        @Incoming(topic = NON_PARALLEL_IN)
+        @Outgoing(topic = NON_PARALLEL_OUT)
+        public CompletionStage<MockPayload> handleNonParallel(MockPayload payload) {
+            manager.getReceiver(NON_PARALLEL_IN).receiveMessage(payload);
+            CompletableFuture<MockPayload> future = new CompletableFuture<>();
+            futures.add(future);
+            return future;
+        }
+
+        private final AtomicBoolean syncFailed = new AtomicBoolean();
+
+        public AtomicBoolean getSyncFailed() {
+            return syncFailed;
+        }
+
+        @Incoming(topic = SYNC_FAILING_IN)
+        @Outgoing(topic = SYNC_FAILING_OUT)
+        public CompletionStage<MockPayload> handleSyncFailing(MockPayload payload) {
+            if (payload.getField1().equals("fail") && !syncFailed.getAndSet(true)) {
+                manager.getReceiver(SYNC_FAILING_IN).receiveMessage(payload);
+                throw new QuietRuntimeException("failed");
+            }
+            else {
+                manager.getReceiver(SYNC_FAILING_IN).receiveMessage(payload);
+                return CompletableFuture.completedFuture(payload.transform());
+            }
+        }
+
+        private final AtomicBoolean asyncFailed = new AtomicBoolean();
+
+        public AtomicBoolean getAsyncFailed() {
+            return asyncFailed;
+        }
+
+
+        @Incoming(topic = ASYNC_FAILING_IN)
+        @Outgoing(topic = ASYNC_FAILING_OUT)
+        public CompletionStage<MockPayload> handleAsyncFailing(MockPayload payload) {
+            if (payload.getField1().equals("fail") && !asyncFailed.getAndSet(true)) {
+                manager.getReceiver(ASYNC_FAILING_IN).receiveMessage(payload);
+                CompletableFuture<MockPayload> future = new CompletableFuture<>();
+                future.completeExceptionally(new QuietRuntimeException("failed"));
+                return future;
+            }
+            else {
+                manager.getReceiver(ASYNC_FAILING_IN).receiveMessage(payload);
+                return CompletableFuture.completedFuture(payload.transform());
+            }
+        }
+
+        private final AtomicBoolean wrappedFailed = new AtomicBoolean();
+
+        public AtomicBoolean getWrappedFailed() {
+            return wrappedFailed;
+        }
+
+        @Incoming(topic = WRAPPED_MESSAGE_IN)
+        @Outgoing(topic = WRAPPED_MESSAGE_OUT)
+        public CompletionStage<MockPayload> handleWrapped(Message<MockPayload> msg) {
+            if (msg.getPayload().getField1().equals("acknowledged") || wrappedFailed.get()) {
+                manager.<MockPayload>getReceiver(WRAPPED_MESSAGE_IN).receiveWrappedMessage(msg);
+                return msg.ack().thenApply(v -> msg.getPayload().transform());
+            }
+            else if (msg.getPayload().getField1().equals("fail")) {
+                wrappedFailed.set(true);
+                manager.<MockPayload>getReceiver(WRAPPED_MESSAGE_IN).receiveWrappedMessage(msg);
+                throw new QuietRuntimeException("failed");
+            }
+            else {
+                manager.<MockPayload>getReceiver(WRAPPED_MESSAGE_IN).receiveWrappedMessage(msg);
+                return CompletableFuture.completedFuture(msg.getPayload().transform());
+            }
+        }
+
+        private final AtomicInteger acked = new AtomicInteger();
+        private final AtomicBoolean outgoingWrappedFailed = new AtomicBoolean();
+
+        public AtomicInteger getAcked() {
+            return acked;
+        }
+
+        public AtomicBoolean getOutgoingWrappedFailed() {
+            return outgoingWrappedFailed;
+        }
+
+        @Incoming(topic = OUTGOING_WRAPPED_IN)
+        @Outgoing(topic = OUTGOING_WRAPPED_OUT)
+        public CompletionStage<Message<MockPayload>> handleOutgoingWrapped(MockPayload msg) {
+            if (msg.getField1().equals("fail") && !outgoingWrappedFailed.getAndSet(true)) {
+                manager.getReceiver(OUTGOING_WRAPPED_IN).receiveMessage(msg);
+                throw new QuietRuntimeException("failed");
+            }
+            else {
+                manager.getReceiver(OUTGOING_WRAPPED_IN).receiveMessage(msg);
+                return CompletableFuture.completedFuture(Message.of(msg.transform(), () -> {
+                    acked.incrementAndGet();
+                    return CompletableFuture.completedFuture(null);
+                }));
+            }
+        }
+
+        private final AtomicBoolean incomingOutgoingWrappedFailed = new AtomicBoolean();
+
+        public AtomicBoolean getIncomingOutgoingWrappedFailed() {
+            return incomingOutgoingWrappedFailed;
+        }
+
+        // This is used to ensure that before we fail the stream, the first message was successfully acked.
+        private final CompletableFuture<Void> incomingOutgoingWrappedAcked = new CompletableFuture<>();
+
+        @Incoming(topic = INCOMING_OUTGOING_WRAPPED_IN)
+        @Outgoing(topic = INCOMING_OUTGOING_WRAPPED_OUT)
+        public CompletionStage<Message<MockPayload>> handleIncomingOutgoingWrapped(Message<MockPayload> msg) {
+            if (msg.getPayload().getField1().equals("acknowledged") || incomingOutgoingWrappedFailed.get()) {
+                manager.<MockPayload>getReceiver(INCOMING_OUTGOING_WRAPPED_IN).receiveWrappedMessage(msg);
+                return CompletableFuture.completedFuture(Message.of(msg.getPayload().transform(), () ->
+                    msg.ack().thenAccept(incomingOutgoingWrappedAcked::complete)
+                ));
+            }
+            else if (msg.getPayload().getField1().equals("fail")) {
+                incomingOutgoingWrappedFailed.set(true);
+                manager.<MockPayload>getReceiver(INCOMING_OUTGOING_WRAPPED_IN).receiveWrappedMessage(msg);
+                return incomingOutgoingWrappedAcked.thenApply(v -> {
+                    throw new QuietRuntimeException("failed");
+                });
+            }
+            else {
+                manager.<MockPayload>getReceiver(INCOMING_OUTGOING_WRAPPED_IN).receiveWrappedMessage(msg);
+                // Note - not transferring the ack.
+                return CompletableFuture.completedFuture(Message.of(msg.getPayload().transform()));
+            }
+        }
+    }
+
+    @Test
+    public void simpleCompletionStageVoidMethodShouldProcessMessages() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(SIMPLE_IN);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+        MockPayload msg3 = new MockPayload("mock", 3);
+
+        puppet.sendPayloads(SIMPLE_IN, msg1, msg2);
+
+        receiver.expectNextMessageWithPayload(msg1);
+        puppet.expectNextMessageWithPayload(SIMPLE_OUT, msg1.transform());
+        receiver.expectNextMessageWithPayload(msg2);
+        puppet.expectNextMessageWithPayload(SIMPLE_OUT, msg2.transform());
+        receiver.expectNoMessages("Didn't expect a message because didn't send one.");
+        puppet.expectNoMessages(SIMPLE_OUT);
+
+        puppet.sendPayloads(SIMPLE_IN, msg3);
+        receiver.expectNextMessageWithPayload(msg3);
+        puppet.expectNextMessageWithPayload(SIMPLE_OUT, msg3.transform());
+    }
+
+    @Test
+    public void completionStageMethodShouldNotProcessMessagesInParallel() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(NON_PARALLEL_IN);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+        MockPayload msg3 = new MockPayload("mock", 3);
+
+        puppet.sendPayloads(NON_PARALLEL_IN, msg1, msg2);
+
+        receiver.expectNextMessageWithPayload(msg1);
+        receiver.expectNoMessages("Did not redeem future from previous message yet.");
+        bean.getFutures().removeFirst().complete(msg1.transform());
+        puppet.expectNextMessageWithPayload(NON_PARALLEL_OUT, msg1.transform());
+        receiver.expectNextMessageWithPayload(msg2);
+        receiver.expectNoMessages("Did not redeem future from previous message yet.");
+        bean.getFutures().removeFirst().complete(msg2.transform());
+        puppet.expectNextMessageWithPayload(NON_PARALLEL_OUT, msg2.transform());
+        puppet.sendPayloads(NON_PARALLEL_IN, msg3);
+        receiver.expectNextMessageWithPayload(msg3);
+        bean.getFutures().removeFirst().complete(msg3.transform());
+        puppet.expectNextMessageWithPayload(NON_PARALLEL_OUT, msg3.transform());
+    }
+
+    @Test(groups = {"ack"})
+    public void completionStageMethodShouldRetryMessagesThatFailSynchronously() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(SYNC_FAILING_IN);
+        MockPayload msg1 = new MockPayload("fail", 1);
+        MockPayload msg2 = new MockPayload("success", 2);
+
+        puppet.sendPayloads(SYNC_FAILING_IN, msg1, msg2);
+        // We should receive the fail message once, then failed should be true, then we should receive it again,
+        // followed by the next message.
+        receiver.expectNextMessageWithPayload(msg1);
+        assertTrue(bean.getSyncFailed().get(), "Sync was not failed");
+        receiver.expectNextMessageWithPayload(msg1);
+        puppet.expectNextMessageWithPayload(SYNC_FAILING_OUT, msg1.transform());
+        receiver.expectNextMessageWithPayload(msg2);
+        puppet.expectNextMessageWithPayload(SYNC_FAILING_OUT, msg2.transform());
+    }
+
+    @Test(groups = {"ack"})
+    public void completionStageMethodShouldRetryMessagesThatFailAsynchronously() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(ASYNC_FAILING_IN);
+        MockPayload msg1 = new MockPayload("fail", 1);
+        MockPayload msg2 = new MockPayload("success", 2);
+
+        puppet.sendPayloads(ASYNC_FAILING_IN, msg1, msg2);
+        // We should receive the fail message once, then failed should be true, then we should receive it again,
+        // followed by the next message.
+        receiver.expectNextMessageWithPayload(msg1);
+        assertTrue(bean.getAsyncFailed().get(), "Async was not failed");
+        receiver.expectNextMessageWithPayload(msg1);
+        puppet.expectNextMessageWithPayload(ASYNC_FAILING_OUT, msg1.transform());
+        receiver.expectNextMessageWithPayload(msg2);
+        puppet.expectNextMessageWithPayload(ASYNC_FAILING_OUT, msg2.transform());
+    }
+
+    @Test(groups = {"ack"})
+    public void completionStageMethodShouldNotAutomaticallyAcknowledgeWrappedMessages() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(WRAPPED_MESSAGE_IN);
+        MockPayload msg1 = new MockPayload("acknowledged", 1);
+        MockPayload msg2 = new MockPayload("unacknowledged", 2);
+        MockPayload msg3 = new MockPayload("fail", 3);
+        MockPayload msg4 = new MockPayload("success", 4);
+
+        puppet.sendPayloads(WRAPPED_MESSAGE_IN, msg1, msg2, msg3, msg4);
+        // First one should be acknwoldeged. The second one gets processed successfully, but first time, doesn't ack.
+        // Third one fails on the first attempt, on the second acks. Fourth one always acks.
+        receiver.expectNextMessageWithPayload(msg1);
+        puppet.expectNextMessageWithPayload(WRAPPED_MESSAGE_OUT, msg1.transform());
+        receiver.expectNextMessageWithPayload(msg2);
+        puppet.expectNextMessageWithPayload(WRAPPED_MESSAGE_OUT, msg2.transform());
+        receiver.expectNextMessageWithPayload(msg3);
+        assertTrue(bean.getWrappedFailed().get(), "Wrapped was not failed");
+        receiver.expectNextMessageWithPayload(msg2);
+        puppet.expectNextMessageWithPayload(WRAPPED_MESSAGE_OUT, msg2.transform());
+        receiver.expectNextMessageWithPayload(msg3);
+        puppet.expectNextMessageWithPayload(WRAPPED_MESSAGE_OUT, msg3.transform());
+        receiver.expectNextMessageWithPayload(msg4);
+        puppet.expectNextMessageWithPayload(WRAPPED_MESSAGE_OUT, msg4.transform());
+    }
+
+    @Test(groups = {"ack"})
+    public void completionStageWithOutgoingWrappedMessageShouldGetAcknowledged() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(OUTGOING_WRAPPED_IN);
+        MockPayload msg1 = new MockPayload("fail", 1);
+        MockPayload msg2 = new MockPayload("success", 2);
+
+        puppet.sendPayloads(OUTGOING_WRAPPED_IN, msg1, msg2);
+        receiver.expectNextMessageWithPayload(msg1);
+        assertTrue(bean.getOutgoingWrappedFailed().get(), "Outgoing wrapped was not failed");
+
+        receiver.expectNextMessageWithPayload(msg1);
+        puppet.expectNextMessageWithPayload(OUTGOING_WRAPPED_OUT, msg1.transform());
+        receiver.expectNextMessageWithPayload(msg2);
+        puppet.expectNextMessageWithPayload(OUTGOING_WRAPPED_OUT, msg2.transform());
+        waitUntil(environment.receiveTimeout(), () -> assertEquals(bean.getAcked().get(), 2));
+    }
+
+    @Test(groups = {"ack"})
+    public void completionStageMethodShouldAcknowldegePassedThroughAckFunctions() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(INCOMING_OUTGOING_WRAPPED_IN);
+        MockPayload msg1 = new MockPayload("acknowledged", 1);
+        MockPayload msg2 = new MockPayload("unacknowledged", 2);
+        MockPayload msg3 = new MockPayload("fail", 3);
+        MockPayload msg4 = new MockPayload("success", 4);
+
+        puppet.sendPayloads(INCOMING_OUTGOING_WRAPPED_IN, msg1, msg2, msg3, msg4);
+        receiver.expectNextMessageWithPayload(msg1);
+        puppet.expectNextMessageWithPayload(INCOMING_OUTGOING_WRAPPED_OUT, msg1.transform());
+        receiver.expectNextMessageWithPayload(msg2);
+        puppet.expectNextMessageWithPayload(INCOMING_OUTGOING_WRAPPED_OUT, msg2.transform());
+        receiver.expectNextMessageWithPayload(msg3);
+        assertTrue(bean.getIncomingOutgoingWrappedFailed().get(), "Wrapped was not failed");
+        receiver.expectNextMessageWithPayload(msg2);
+        puppet.expectNextMessageWithPayload(INCOMING_OUTGOING_WRAPPED_OUT, msg2.transform());
+        receiver.expectNextMessageWithPayload(msg3);
+        puppet.expectNextMessageWithPayload(INCOMING_OUTGOING_WRAPPED_OUT, msg3.transform());
+        receiver.expectNextMessageWithPayload(msg4);
+        puppet.expectNextMessageWithPayload(INCOMING_OUTGOING_WRAPPED_OUT, msg4.transform());
+    }
+}

--- a/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/IncomingProcessorMethodVerification.java
+++ b/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/IncomingProcessorMethodVerification.java
@@ -1,0 +1,343 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.eclipse.microprofile.reactive.messaging.tck;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.tck.container.ContainerPuppet;
+import org.eclipse.microprofile.reactive.messaging.tck.container.MockPayload;
+import org.eclipse.microprofile.reactive.messaging.tck.container.MockedReceiver;
+import org.eclipse.microprofile.reactive.messaging.tck.container.MockedSender;
+import org.eclipse.microprofile.reactive.messaging.tck.container.QuietRuntimeException;
+import org.eclipse.microprofile.reactive.messaging.tck.container.TckDeploymentUtils;
+import org.eclipse.microprofile.reactive.messaging.tck.container.TestEnvironment;
+import org.eclipse.microprofile.reactive.messaging.tck.container.Topics;
+import org.eclipse.microprofile.reactive.messaging.tck.container.WaitAssert;
+import org.eclipse.microprofile.reactive.streams.ProcessorBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.testng.annotations.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Provides tests for methods of the shape:
+ *
+ * <pre>
+ * &#064;Incoming
+ * public ProcessorBuilder&gt;SomeMessage, Void&lt; process() {
+ *   ...
+ * }
+ * </pre>
+ */
+@Test(groups = {"all", "incoming"})
+public class IncomingProcessorMethodVerification extends Arquillian {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return TckDeploymentUtils.createDeployment(Bean.class);
+    }
+
+    private static final String SIMPLE = "simple";
+    private static final String COMPLETING = "completing";
+    private static final String FAILING = "failing";
+    private static final String FAILING_IMPLICIT_ACK = "failing-implicit-ack";
+    private static final String WRAPPED_INCOMING = "wrapped-incoming";
+    private static final String WRAPPED_INCOMING_ACK = "wrapped-incoming-ack";
+    private static final String WRAPPED_OUTGOING = "wrapped-outgoing";
+    private static final String WRAPPED_OUTGOING_ACK = "wrapped-outgoing-ack";
+    private static final String WRAPPED_INCOMING_OUTGOING = "wrapped-incoming-outgoing";
+    private static final String WRAPPED_INCOMING_OUTGOING_ACK = "wrapped-incoming-outgoing-ack";
+
+    @Topics
+    public static String[] topics() {
+        return new String[]{
+            SIMPLE, COMPLETING, FAILING, FAILING_IMPLICIT_ACK, WRAPPED_INCOMING, WRAPPED_INCOMING_ACK, WRAPPED_OUTGOING,
+            WRAPPED_OUTGOING_ACK, WRAPPED_INCOMING_OUTGOING, WRAPPED_INCOMING_OUTGOING_ACK
+        };
+    }
+
+
+    @ArquillianResource
+    private ContainerPuppet controller;
+    @ArquillianResource
+    private TestEnvironment environment;
+
+    @Inject
+    private TckMessagingManager manager;
+
+    @Inject
+    private Bean bean;
+
+    public static final class Unit {
+    }
+    private static final Unit UNIT = new Unit();
+
+    @ApplicationScoped
+    public static class Bean {
+
+        @Inject
+        private TckMessagingManager manager;
+
+        @Incoming(topic = SIMPLE)
+        public ProcessorBuilder<MockPayload, Unit> handleSimple() {
+            return manager.<MockPayload>getReceiver(SIMPLE).createProcessor(
+                manager.<Unit>getSender(SIMPLE).createPublisher());
+        }
+
+        @Incoming(topic = COMPLETING)
+        public ProcessorBuilder<MockPayload, Unit> handleCompleting() {
+            return manager.<MockPayload>getReceiver(COMPLETING).createProcessor(
+                manager.<Unit>getSender(COMPLETING).createPublisher());
+        }
+
+        @Incoming(topic = FAILING)
+        public ProcessorBuilder<MockPayload, Unit> handleFailing() {
+            return manager.<MockPayload>getReceiver(FAILING).createProcessor(
+                manager.<Unit>getSender(FAILING).createPublisher());
+        }
+
+        @Incoming(topic = FAILING_IMPLICIT_ACK)
+        public ProcessorBuilder<MockPayload, Unit> handleCompletingImplicitAck() {
+            return manager.<MockPayload>getReceiver(FAILING_IMPLICIT_ACK).createProcessor(
+                manager.<Unit>getSender(FAILING_IMPLICIT_ACK).createPublisher());
+        }
+
+        @Incoming(topic = WRAPPED_INCOMING)
+        public ProcessorBuilder<Message<MockPayload>, Unit> handleWrappedIncoming() {
+            return manager.<MockPayload>getReceiver(WRAPPED_INCOMING).createWrappedProcessor(
+                manager.<Unit>getSender(WRAPPED_INCOMING).createPublisher());
+        }
+
+        @Incoming(topic = WRAPPED_INCOMING_ACK)
+        public ProcessorBuilder<Message<MockPayload>, Unit> handleWrappedIncomingAck() {
+            return manager.<MockPayload>getReceiver(WRAPPED_INCOMING_ACK).createWrappedProcessor(
+                manager.<Unit>getSender(WRAPPED_INCOMING_ACK).createPublisher());
+        }
+
+        @Incoming(topic = WRAPPED_OUTGOING)
+        public ProcessorBuilder<MockPayload, Message<Unit>> handleWrappedOutgoing() {
+            return manager.<MockPayload>getReceiver(WRAPPED_OUTGOING).createProcessor(
+                manager.<Unit>getSender(WRAPPED_OUTGOING).createWrappedPublisher());
+        }
+
+        @Incoming(topic = WRAPPED_OUTGOING_ACK)
+        public ProcessorBuilder<MockPayload, Message<Unit>> handleWrappedOutgoingAck() {
+            return manager.<MockPayload>getReceiver(WRAPPED_OUTGOING_ACK).createProcessor(
+                manager.<Unit>getSender(WRAPPED_OUTGOING_ACK).createWrappedPublisher());
+        }
+
+        @Incoming(topic = WRAPPED_INCOMING_OUTGOING)
+        public ProcessorBuilder<Message<MockPayload>, Message<Unit>> handleWrappedIncomingOutgoing() {
+            return manager.<MockPayload>getReceiver(WRAPPED_INCOMING_OUTGOING).createWrappedProcessor(
+                manager.<Unit>getSender(WRAPPED_INCOMING_OUTGOING).createWrappedPublisher());
+        }
+
+        @Incoming(topic = WRAPPED_INCOMING_OUTGOING_ACK)
+        public ProcessorBuilder<Message<MockPayload>, Message<Unit>> handleWrappedIncomingOutgoingAck() {
+            return manager.<MockPayload>getReceiver(WRAPPED_INCOMING_OUTGOING_ACK).createWrappedProcessor(
+                manager.<Unit>getSender(WRAPPED_INCOMING_OUTGOING_ACK).createWrappedPublisher());
+        }
+
+    }
+
+    @Test
+    public void simpleProcessorBuilderMethodShouldHandleMessages() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(SIMPLE);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+        MockPayload msg3 = new MockPayload("mock", 3);
+
+        controller.sendPayloads(SIMPLE, msg1, msg2);
+
+        receiver.expectNextMessageWithPayload(msg1);
+        receiver.expectNextMessageWithPayload(msg2);
+        receiver.expectNoMessages("Didn't expect a message because didn't send one.");
+        controller.sendPayloads(SIMPLE, msg3);
+        receiver.expectNextMessageWithPayload(msg3);
+    }
+
+    @Test
+    public void simpleProcessorBuilderMethodShouldNotRestartWhenCompleted() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(COMPLETING);
+        MockedSender<Unit> sender = manager.getSender(COMPLETING);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+        controller.sendPayloads(COMPLETING, msg1);
+        receiver.expectNextMessageWithPayload(msg1);
+        receiver.cancelAll();
+        sender.completeAll();
+        controller.sendPayloads(COMPLETING, msg2);
+        receiver.expectNoMessages("The receiver must have been restarted.");
+    }
+
+
+    @Test
+    public void simpleProcessorBuilderMethodShouldRestartWhenFailed() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(FAILING);
+        MockedSender<Unit> sender = manager.getSender(FAILING);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+        controller.sendPayloads(FAILING, msg1);
+        receiver.expectNextMessageWithPayload(msg1);
+        sender.send(UNIT);
+        receiver.cancelAll();
+        sender.failAll(new QuietRuntimeException("failed"));
+
+        controller.sendPayloads(FAILING, msg2);
+        // We might receive msg1 again if the acknowledgement didn't arrive before the subscription was shut down.
+        receiver.expectEventualMessageWithPayload(msg2);
+    }
+
+    @Test(groups = "ack")
+    public void simpleProcessorBuilderShouldImplicitlyAckMessagesBasedOnOutput() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(FAILING_IMPLICIT_ACK);
+        MockedSender<Unit> sender = manager.getSender(FAILING_IMPLICIT_ACK);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+
+        controller.sendPayloads(FAILING_IMPLICIT_ACK, msg1, msg2);
+        receiver.expectNextMessageWithPayload(msg1);
+        receiver.expectNextMessageWithPayload(msg2);
+        sender.send(UNIT);
+        receiver.cancelAll();
+        sender.failAll(new QuietRuntimeException("failed"));
+
+        // msg2 should be received again because we didn't implicitly acknowledge it
+        receiver.expectNextMessageWithPayload(msg2);
+    }
+
+    @Test
+    public void wrappedIncomingProcessorMethodShouldWork() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(WRAPPED_INCOMING);
+        MockPayload msg1 = new MockPayload("mock", 1);
+
+        controller.sendPayloads(WRAPPED_INCOMING, msg1);
+        receiver.expectNextMessageWithPayload(msg1);
+    }
+
+    @Test(groups = "ack")
+    public void wrappedIncomingProcessorMethodShouldOnlyAckWhenAckMethodInvoked() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(WRAPPED_INCOMING_ACK);
+        MockedSender<Unit> sender = manager.getSender(WRAPPED_INCOMING_ACK);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+
+        controller.sendPayloads(WRAPPED_INCOMING_ACK, msg1, msg2);
+        Message<MockPayload> rcvd1 = receiver.expectNextMessageWithPayload(msg1);
+        receiver.expectNextMessageWithPayload(msg2);
+
+        // Now emit two messages, these shouldn't cause them to ack
+        sender.send(UNIT, UNIT);
+
+        // And explicitly ack the first message, wait for it
+        WaitAssert.await(rcvd1.ack(), environment);
+
+        // Now if we fail and start back up, we should receive the second again
+        receiver.cancelAll();
+        sender.failAll(new QuietRuntimeException("failed"));
+
+        receiver.expectNextMessageWithPayload(msg2);
+    }
+
+    @Test
+    public void wrappedOutgoingProcessorMethodShouldHaveItsAckFunctionInvoked() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(WRAPPED_OUTGOING);
+        MockedSender<Unit> sender = manager.getSender(WRAPPED_OUTGOING);
+        MockPayload msg1 = new MockPayload("mock", 1);
+
+        controller.sendPayloads(WRAPPED_OUTGOING, msg1);
+        receiver.expectNextMessageWithPayload(msg1);
+
+        CompletableFuture<Void> acked = new CompletableFuture<>();
+        sender.send(Message.of(UNIT, () -> {
+            acked.complete(null);
+            return acked;
+        }));
+
+        WaitAssert.await(acked, environment);
+    }
+
+    @Test(groups = "ack")
+    public void wrappedOutgoingProcessorBuilderShouldImplicitlyAckMessagesBasedOnOutput() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(WRAPPED_OUTGOING_ACK);
+        MockedSender<Unit> sender = manager.getSender(WRAPPED_OUTGOING_ACK);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+
+        controller.sendPayloads(WRAPPED_OUTGOING_ACK, msg1, msg2);
+        receiver.expectNextMessageWithPayload(msg1);
+        receiver.expectNextMessageWithPayload(msg2);
+        sender.send(UNIT);
+        receiver.cancelAll();
+        sender.failAll(new QuietRuntimeException("failed"));
+
+        // msg2 should be received again because we didn't implicitly acknowledge it
+        receiver.expectNextMessageWithPayload(msg2);
+    }
+
+
+    @Test
+    public void wrappedIncomingOutgoingProcessorMethodShouldWork() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(WRAPPED_INCOMING_OUTGOING);
+        MockPayload msg1 = new MockPayload("mock", 1);
+
+        controller.sendPayloads(WRAPPED_INCOMING_OUTGOING, msg1);
+        receiver.expectNextMessageWithPayload(msg1);
+    }
+
+    @Test(groups = "ack")
+    public void wrappedIncomingOutgoingProcessorMethodShouldOnlyAckMessagesThroughTheOutgoingAckFunction() {
+        MockedReceiver<MockPayload> receiver = manager.getReceiver(WRAPPED_INCOMING_OUTGOING_ACK);
+        MockedSender<Unit> sender = manager.getSender(WRAPPED_INCOMING_OUTGOING_ACK);
+        MockPayload msg1 = new MockPayload("mock", 1);
+        MockPayload msg2 = new MockPayload("mock", 2);
+
+        controller.sendPayloads(WRAPPED_INCOMING_OUTGOING_ACK, msg1, msg2);
+        Message<MockPayload> rcvd1 = receiver.expectNextMessageWithPayload(msg1);
+        receiver.expectNextMessageWithPayload(msg2);
+
+        // Now propagate the first ack function, but not the second
+        CompletableFuture<Void> acked2 = new CompletableFuture<>();
+        sender.send(Message.of(UNIT, () -> rcvd1.ack()), Message.of(UNIT, () -> {
+            acked2.complete(null);
+            return acked2;
+        }));
+
+        // Wait for the second to be acked
+        WaitAssert.await(acked2, environment);
+
+        // Now if we fail and start back up, we should receive the second again
+        receiver.cancelAll();
+        sender.failAll(new QuietRuntimeException("failed"));
+
+        receiver.expectNextMessageWithPayload(msg2);
+    }
+
+
+}

--- a/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ReactiveMessagingTck.java
+++ b/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ReactiveMessagingTck.java
@@ -32,7 +32,8 @@ public class ReactiveMessagingTck {
     public Object[] getAllTests() {
         return new Object[]{
             new IncomingCompletionStageMethodVerification(),
-            new IncomingOutgingCompletionStageMethodVerification()
+            new IncomingOutgingCompletionStageMethodVerification(),
+            new IncomingProcessorMethodVerification()
         };
     }
 

--- a/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ReactiveMessagingTck.java
+++ b/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ReactiveMessagingTck.java
@@ -31,7 +31,8 @@ public class ReactiveMessagingTck {
     @Factory
     public Object[] getAllTests() {
         return new Object[]{
-            new CompletionStageIncomingMethodVerification()
+            new IncomingCompletionStageMethodVerification(),
+            new IncomingOutgingCompletionStageMethodVerification()
         };
     }
 

--- a/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/MockPayload.java
+++ b/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/MockPayload.java
@@ -49,6 +49,10 @@ public class MockPayload {
         this.field2 = field2;
     }
 
+    public MockPayload transform() {
+        return new MockPayload("transformed " + field1, 100 + field2);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/Topics.java
+++ b/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/Topics.java
@@ -27,8 +27,7 @@ import java.lang.annotation.Target;
 /**
  * Used to specify the topics that a TCK test works with.
  */
-@Target(ElementType.TYPE)
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Topics {
-    String[] value();
 }

--- a/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/WaitAssert.java
+++ b/messaging/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/WaitAssert.java
@@ -20,6 +20,9 @@
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class WaitAssert {
 
@@ -42,4 +45,15 @@ public class WaitAssert {
         }
     }
 
+    public static <T> T await(CompletionStage<T> future, TestEnvironment environment) {
+        try {
+            return future.toCompletableFuture().get(environment.receiveTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        catch (TimeoutException e) {
+            throw new AssertionError("Action was not completed in " + environment.receiveTimeout().toMillis() + "ms", e);
+        }
+        catch (Exception e) {
+            throw new AssertionError("Action failed", e);
+        }
+    }
 }


### PR DESCRIPTION
This test adds support for CompletionStage returning methods that are annotated with both Incoming and Outgoing annotations.

In addition, I changed the `@Topics` annotation to be put on a method, like `@Deployments`, this makes it a lot cleaner to use in practice.