### PR TITLE
More work on the streams spec

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/ProcessorBuilder.java
@@ -182,12 +182,7 @@ public final class ProcessorBuilder<T, R> {
      * @throws IllegalArgumentException If {@code maxSize} is less than zero.
      */
     public ProcessorBuilder<T, R> limit(long maxSize) {
-        if (maxSize < 0) {
-            throw new IllegalArgumentException("Cannot limit a stream to less than zero elements.");
-        }
-        else {
-            return addStage(new Stage.Limit(maxSize));
-        }
+        return addStage(new Stage.Limit(maxSize));
     }
 
     /**
@@ -199,9 +194,6 @@ public final class ProcessorBuilder<T, R> {
      * @throws IllegalArgumentException If {@code n} is less than zero.
      */
     public ProcessorBuilder<T, R> skip(long n) {
-        if (n < 0) {
-            throw new IllegalArgumentException("Cannot skip less than zero elements");
-        }
         return addStage(new Stage.Skip(n));
     }
 
@@ -402,7 +394,7 @@ public final class ProcessorBuilder<T, R> {
      * encountered.
      *
      * @param errorHandler the function returning the value that need to be emitting instead of the error.
-     *                     The function must not return {@code null}
+     *                     The function must not return {@code null}.
      * @return The new processor
      */
     public ProcessorBuilder<T, R> onErrorResume(Function<Throwable, R> errorHandler) {
@@ -423,7 +415,7 @@ public final class ProcessorBuilder<T, R> {
      * may never know that an error happened.
      *
      * @param errorHandler the function returning the stream that need to be emitting instead of the error.
-     *                     The function must not return {@code null}
+     *                     The function must not return {@code null}.
      * @return The new processor
      */
     public ProcessorBuilder<T, R> onErrorResumeWith(Function<Throwable, PublisherBuilder<R>> errorHandler) {
@@ -444,7 +436,7 @@ public final class ProcessorBuilder<T, R> {
      * may never know that an error happened.
      *
      * @param errorHandler the function returning the stream that need to be emitting instead of the error.
-     *                     The function must not return {@code null}
+     *                     The function must not return {@code null}.
      * @return The new processor
      */
     public ProcessorBuilder<T, R> onErrorResumeWithPublisher(Function<Throwable, Publisher<R>> errorHandler) {

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/PublisherBuilder.java
@@ -182,12 +182,7 @@ public final class PublisherBuilder<T> {
      * @throws IllegalArgumentException If {@code maxSize} is less than zero.
      */
     public PublisherBuilder<T> limit(long maxSize) {
-        if (maxSize < 0) {
-            throw new IllegalArgumentException("Cannot limit a stream to less than zero elements.");
-        }
-        else {
-            return addStage(new Stage.Limit(maxSize));
-        }
+        return addStage(new Stage.Limit(maxSize));
     }
 
     /**
@@ -199,9 +194,6 @@ public final class PublisherBuilder<T> {
      * @throws IllegalArgumentException If {@code n} is less than zero.
      */
     public PublisherBuilder<T> skip(long n) {
-        if (n < 0) {
-            throw new IllegalArgumentException("Cannot skip less than zero elements");
-        }
         return addStage(new Stage.Skip(n));
     }
 

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreams.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/ReactiveStreams.java
@@ -61,7 +61,8 @@ public class ReactiveStreams {
      * @return A publisher builder that will emit the element.
      */
     public static <T> PublisherBuilder<T> of(T t) {
-        return new PublisherBuilder<>(new Stage.Of(Collections.singletonList(t)));
+        return new PublisherBuilder<>(new Stage.Of(Collections.singletonList(
+            Objects.requireNonNull(t, "Reactive Streams does not support null elements"))));
     }
 
     /**

--- a/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/Stage.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/streams/spi/Stage.java
@@ -83,10 +83,12 @@ public interface Stage {
     /**
      * A map stage.
      * <p>
-     * The given mapper function should be invoked on each element consumed, and the output of the function should be
+     * The given mapper function must be invoked on each element consumed, and the output of the function must be
      * emitted.
      * <p>
-     * Any {@link RuntimeException} thrown by the function should be propagated down the stream as an error.
+     * Any {@link RuntimeException} thrown by the function must be propagated downstream as an error, and upstream
+     * must be cancelled. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
      */
     final class Map implements Inlet, Outlet {
         private final Function<?, ?> mapper;
@@ -107,11 +109,13 @@ public interface Stage {
 
     /**
      * A stage returning a stream containing all the elements from this stream,
-     * additionaly perfoming the provided action on each element.
+     * additionally performing the provided action on each element.
      * <p>
-     * The given consumer function should be invoked on each element consumed.
+     * The given consumer function must be invoked on each element consumed.
      * <p>
-     * Any {@link RuntimeException} thrown by the function should be propagated down the stream as an error.
+     * Any {@link RuntimeException} thrown by the function must be propagated downstream as an error, and upstream
+     * must be cancelled. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
      */
     final class Peek implements Inlet, Outlet {
         private final Consumer<?> consumer;
@@ -133,10 +137,12 @@ public interface Stage {
     /**
      * A filter stage.
      * <p>
-     * The given predicate should be invoked on each element consumed. If it returns true, the element should be
-     * emitted.
+     * The given predicate must be invoked on each element consumed. If it returns {@code true}, the element must be
+     * emitted, otherwise, it must be dropped.
      * <p>
-     * Any {@link RuntimeException} thrown by the predicate should be propagated down the stream as an error.
+     * Any {@link RuntimeException} thrown by the predicate must be propagated downstream as an error, and upstream
+     * must be cancelled. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
      */
     final class Filter implements Inlet, Outlet {
         private final Predicate<?> predicate;
@@ -158,10 +164,17 @@ public interface Stage {
     /**
      * A drop while stage.
      * <p>
-     * The given predicate should be invoked on each element consumed, until it returns true. Each element that it
-     * returns true for should be dropped, once it returns false, then all elements should be emitted.
+     * The given predicate must be invoked on each element consumed, until it returns {@code true}. Each element that it
+     * returns {@code true} for must be dropped, and once it returns {@code false}, that element that it returned
+     * {@code false} for, and all subsequent elements, must be emitted. The predicate must not be invoked after it returns
+     * {@code false} the first time.
      * <p>
-     * Any {@link RuntimeException} thrown by the predicate should be propagated down the stream as an error.
+     * If upstream terminates for any reason before the predicate returns {@code false}, downstream must also be
+     * terminated.
+     * <p>
+     * Any {@link RuntimeException} thrown by the predicate must be propagated downstream as an error, and upstream
+     * must be cancelled. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
      */
     final class DropWhile implements Inlet, Outlet {
         private final Predicate<?> predicate;
@@ -183,12 +196,26 @@ public interface Stage {
     /**
      * A skip stage.
      * <p>
-     * The first {@code skip} elements should be skipped, after that all elements should be emitted.
+     * The first {@code skip} elements must be skipped, after that all elements must be emitted.
+     * <p>
+     * If the number of elements to skip is zero, this stage has no effect.
+     * <p>
+     * If less than {@code skip} elements are emitted before termination, then the termination must be propagated
+     * downstream as normal.
      */
     final class Skip implements Inlet, Outlet {
         private final long skip;
 
+        /**
+         * Create a skip stage.
+         *
+         * @param skip The number of elements to skip.
+         * @throws IllegalArgumentException If the number of elements is less than zero.
+         */
         public Skip(long skip) {
+            if (skip < 0) {
+                throw new IllegalArgumentException("Cannot skip less than zero elements");
+            }
             this.skip = skip;
         }
 
@@ -205,12 +232,26 @@ public interface Stage {
     /**
      * A limit stage.
      * <p>
-     * Only {@code limit} elements should be emitted, once that many elements are emitted, the stream should be completed.
+     * Only {@code limit} elements may be emitted, once that many elements are emitted, downstream must be completed,
+     * and upstream must be cancelled. Any subsequent elements received from upstream before the cancellation signal
+     * is handled must be dropped.
+     * <p>
+     * If less than {@code limit} elements are received before termination, then the termination must be propagated
+     * downstream as normal.
      */
     final class Limit implements Inlet, Outlet {
         private final long limit;
 
+        /**
+         * Create a limit stage.
+         *
+         * @param limit The number of elements to limit the stream to.
+         * @throws IllegalArgumentException If the number of elements is less than zero.
+         */
         public Limit(long limit) {
+            if (limit < 0) {
+                throw new IllegalArgumentException("Cannot limit a stream to less than zero elements.");
+            }
             this.limit = limit;
         }
 
@@ -227,9 +268,16 @@ public interface Stage {
     /**
      * A stage returning a stream consisting of the distinct elements (according to {@link Object#equals(Object)}) of this
      * stream.
+     * <p>
+     * Any {@link RuntimeException} thrown by the {@code equals} or {@code hashCode} methods of elements must be
+     * propagated downstream as an error, and upstream must be cancelled.
      */
     final class Distinct implements Inlet, Outlet {
 
+        /**
+         * The singleton instance of the distinct stage. Implementations may use reference equality to test for this
+         * stage.
+         */
         public static final Distinct INSTANCE = new Distinct();
 
         private Distinct() {
@@ -241,10 +289,16 @@ public interface Stage {
     /**
      * A take while stage.
      * <p>
-     * The given predicate should be supplied when the stream is first run, and then invoked on each element consumed.
-     * When it returns true, the element should be emitted, when it returns false the stream should be completed.
+     * The given {@code predicate} must be invoked on each element consumed. While the predicate returns {@code true},
+     * the element must be emitted, when the predicate returns {@code false}, the element must not be emitted, 
+     * downstream must be completed and upstream must be cancelled.
      * <p>
-     * Any {@link RuntimeException} thrown by the predicate should be propagated down the stream as an error.
+     * The {@code predicate} must not be invoked again once it returns {@code false} for the first time. Any elements
+     * supplied by upstream before it handles the cancellation signal must be dropped.
+     * <p>
+     * Any {@link RuntimeException} thrown by the predicate must be propagated downstream as an error, and upstream
+     * must be cancelled. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
      */
     final class TakeWhile implements Inlet, Outlet {
         private final Predicate<?> predicate;
@@ -266,8 +320,8 @@ public interface Stage {
     /**
      * A publisher stage.
      * <p>
-     * The given publisher should be subscribed to whatever subscriber is provided to this graph, via any other subsequent
-     * stages.
+     * The given {@code publisher} must be subscribed to whatever subscriber is provided to this graph, via any
+     * other subsequent stages.
      */
     final class PublisherStage implements Outlet {
         private final Publisher<?> publisher;
@@ -289,14 +343,16 @@ public interface Stage {
     /**
      * A publisher of zero to many values.
      * <p>
-     * When built, should produce a publisher that produces all the values (until cancelled) emitted by this iterables
+     * When built, must produce a publisher that produces all the values (until cancelled) emitted by this iterables
      * iterator, followed by completion of the stream.
      * <p>
-     * Any exceptions thrown by the iterator must be propagated downstream.
+     * Any exceptions thrown by the iterator must be propagated downstream, or by the invocation of the
+     * {@code iterator} method, must be propagated downstream.
      */
     final class Of implements Outlet {
         /**
-         * Instance used for an empty stream.
+         * The singleton instance of the stage used in the case of an empty list. Implementations may use reference
+         * equality to test for this stage.
          */
         public static final Of EMPTY = new Of(Collections.emptyList());
 
@@ -319,7 +375,7 @@ public interface Stage {
     /**
      * A processor stage.
      * <p>
-     * When built, should connect upstream of the graph to the inlet of this processor, and downstream to the outlet.
+     * When built, must connect upstream of the graph to the inlet of this processor, and downstream to the outlet.
      */
     final class ProcessorStage implements Inlet, Outlet {
         private final Processor<?, ?> processor;
@@ -341,14 +397,19 @@ public interface Stage {
     /**
      * A subscriber stage that emits the first element encountered.
      * <p>
-     * When built, the {@link CompletionStage} should emit an {@link java.util.Optional} of the first
-     * element emitted. If no element is emitted before completion of the stream, it should emit an empty optional. Once
-     * the element has been emitted, the stream should be cancelled if not already complete.
+     * When built, the {@link CompletionStage} must emit an {@link java.util.Optional} of the first element
+     * encountered. If no element is emitted before completion of the stream, it must emit an empty optional. Once
+     * the element has been emitted, the stream must be cancelled if not already complete.
      * <p>
      * If an error is emitted before the first element is encountered, the stream must redeem the completion stage with
      * that error.
      */
     final class FindFirst implements Inlet {
+
+        /**
+         * The singleton instance of the find first stage. Implementations may use reference equality to test for this
+         * stage.
+         */
         public static final FindFirst INSTANCE = new FindFirst();
 
         private FindFirst() {
@@ -358,8 +419,8 @@ public interface Stage {
     /**
      * A subscriber.
      * <p>
-     * When built, the {@link CompletionStage} should emit <code>null</code> when the stream
-     * completes normally, or an error if the stream terminates with an error.
+     * When built, the {@link CompletionStage} must emit <code>null</code> when the stream completes normally, or an
+     * error if the stream terminates with an error.
      * <p>
      * Implementing this will typically require inserting a handler before the subscriber that listens for errors.
      */
@@ -383,14 +444,13 @@ public interface Stage {
     /**
      * A collect stage.
      * <p>
-     * This should use the collectors supplier to create an accumulated value, and then the accumulator BiConsumer should
-     * be used to accumulate the received elements in the value. Finally, the returned
-     * {@link CompletionStage} should be redeemed by value returned by the finisher function applied
-     * to the accumulated value when the stream terminates normally, or should be redeemed with an error if the stream
-     * terminates with an error.
+     * This must use the collectors supplier to create an accumulated value, and then the accumulator BiConsumer must
+     * be used to accumulate the received elements in the value. Finally, the returned {@link CompletionStage} must be
+     * redeemed by value returned by the finisher function applied to the accumulated value when the stream terminates
+     * normally, or must be redeemed with an error if the stream terminates with an error.
      * <p>
-     * If the collector throws an exception, the stream must be cancelled, and the
-     * {@link CompletionStage} must be redeemed with that error.
+     * If the collector throws an exception, the upstream must be cancelled, and the {@link CompletionStage} must be
+     * redeemed with that error.
      */
     final class Collect implements Inlet {
         private final Collector<?, ?, ?> collector;
@@ -412,12 +472,28 @@ public interface Stage {
     /**
      * A flat map stage.
      * <p>
-     * The flat map stage should execute the given mapper on each element, and concatenate the publishers emitted by
+     * The flat map stage must execute the given mapper on each element, and concatenate the publishers emitted by
      * the mapper function into the resulting stream.
      * <p>
      * The graph emitted by the mapper function is guaranteed to have an outlet but no inlet.
      * <p>
-     * The engine must be careful to ensure only one publisher emitted by the mapper function is running at a time.
+     * The engine must ensure only one publisher emitted by the mapper function is running at a time.
+     * <p>
+     * Any {@link RuntimeException} thrown by the function must be propagated downstream as an error, and upstream
+     * must be cancelled. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
+     * <p>
+     * If downstream cancels, then both the currently running inner publisher produced by the {@code mapper}, if one
+     * is currently running, and the outer upstream, must be cancelled.
+     * <p>
+     * If the inner publisher terminates with an error, the outer publisher must be cancelled, and the error must be
+     * propagated downstream. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
+     * <p>
+     * If the outer publisher terminates with an error, then implementations may cancel the inner publisher, if one is
+     * currently running, immediately, or they may wait for the inner publisher to complete, before propagating the
+     * error downstream. For the purpose of failing fast, so that network failures can be detected and handled, it
+     * is recommended, but not required, that the inner publisher is cancelled as soon as possible.
      */
     final class FlatMap implements Inlet, Outlet {
         private final Function<?, Graph> mapper;
@@ -439,11 +515,29 @@ public interface Stage {
     /**
      * A flat map stage that emits and flattens {@link CompletionStage}.
      * <p>
-     * The flat map stage should execute the given mapper on each element, and concatenate the values redeemed by the
+     * The flat map stage must execute the given mapper on each element, and concatenate the values redeemed by the
      * {@link CompletionStage}'s emitted by the mapper function into the resulting stream.
      * <p>
-     * The engine must be careful to ensure only one mapper function is executed at a time, with the next mapper function
-     * not executing until the {@link CompletionStage} returned by the previous mapper function has been redeemed.
+     * The engine must ensure only one mapper function is executed at a time, with the next mapper function not
+     * executing until the {@link CompletionStage} returned by the previous mapper function has been redeemed.
+     * <p>
+     * Any {@link RuntimeException} thrown by the function must be propagated downstream as an error, and upstream
+     * must be cancelled. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
+     * <p>
+     * If downstream cancels, then upstream must be cancelled, and if there is a currently executing
+     * {@code CompletionStage}, its result must be ignored.
+     * <p>
+     * If a {@code CompletionStage} is redeemed with an error, upstream must be cancelled, and the error must be
+     * propagated downstream. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
+     * <p>
+     * If upstream terminates with an error, then implementations may decide to ignore the result of any currently
+     * executing {@code CompletionStage}, and propagate the error immediately, or they may wait for the
+     * {@code CompletionStage} to be redeemed, emit its result, and then propagate the error downstream. For the
+     * purpose of failing fast, so that network failures can be detected and handled, it is recommended, but not
+     * required, that the failure is propagated downstream as soon as possible, and the result of the
+     * {@code CompletionStage} ignored.
      */
     final class FlatMapCompletionStage implements Inlet, Outlet {
         private final Function<?, CompletionStage<?>> mapper;
@@ -465,8 +559,25 @@ public interface Stage {
     /**
      * A flat map stage that emits and fattens {@link Iterable}.
      * <p>
-     * The flat map stage should execute the given mapper on each element, and concatenate the iterables emitted by
+     * The flat map stage must execute the given mapper on each element, and concatenate the iterables emitted by
      * the mapper function into the resulting stream.
+     * <p>
+     * Any {@link RuntimeException} thrown by the function must be propagated downstream as an error, and upstream
+     * must be cancelled. Any subsequent elements received from upstream before the cancellation signal is handled
+     * must be dropped.
+     * <p>
+     * If downstream cancels, then upstream must be cancelled, and if there is a current iterator being published, it
+     * must no longer be consumed. The iterator must not be run through to completion in such a circumstance.
+     * <p>
+     * If a currently consumed iterator throws an exception from either its {@code next} or {@code hasNext} methods,
+     * upstream must be cancelled, and the error must be propagated downstream. Any subsequent elements received from
+     * upstream before the cancellation signal is handled must be dropped.
+     * <p>
+     * If upstream terminates with an error, then implementations may decide to stop consuming any currently running
+     * iterator, and propagate the error immediately, or they may run the iterator through to completion, before
+     * propagating the error. For the purpose of failing fast, so that network failures can be detected and handled,
+     * it is recommended, but not required, that the failure is propagated downstream as soon as possible, and the
+     * iterator not be run through to completion.
      */
     final class FlatMapIterable implements Inlet, Outlet {
         private final Function<?, Iterable<?>> mapper;
@@ -489,9 +600,10 @@ public interface Stage {
      * A stage returning a stream containing all the elements from this stream,
      * additionally performing the provided action if this stream conveys an error.
      * <p>
-     * The given consumer function is invoked with the conveyed failure.
+     * The given consumer function must be invoked with the conveyed failure.
      * <p>
-     * Any {@link RuntimeException} thrown by the function should be propagated down the stream as an error.
+     * Any {@link RuntimeException} thrown by the function must be propagated downstream as an error, replacing the
+     * exception that the consumer was handling.
      */
     final class OnError implements Inlet, Outlet {
         private final Consumer<Throwable> consumer;
@@ -512,14 +624,19 @@ public interface Stage {
     }
 
     /**
-     * A stage returning a stream containing all the elements from this stream,
-     * additionally performing the provided action if this stream terminates with an error or completes.
+     * A stage returning a stream containing all the elements from this stream, additionally performing the provided
+     * action if this stream terminates with an error, completes, or is cancelled by downstream.
      * <p>
-     * The given action cannot determine in which case the stream is (error or completed). Use {@link OnError} and
-     * {@link OnComplete} if you need to distinguish the two cases. In addition, the action is called if the stream is
-     * cancelled downstream.
+     * The given action cannot determine in which state the stream is (error, completed or cancelled). Use
+     * {@link OnError} and {@link OnComplete} if you need to distinguish between these cases.
      * <p>
-     * Any {@link RuntimeException} thrown by the function should be propagated down the stream as an error.
+     * The action must only be invoked once. If both upstream completes, and downstream cancels, at the same time,
+     * only one of those signals may trigger the invocation of action.
+     * <p>
+     * If this action is invoked as the result of an upstream completion or error, any {@link RuntimeException} thrown
+     * by the function must be propagated downstream as an error, replacing the exception that the consumer was
+     * handling. If the action is invoked as the result of downstream cancellation, then any exceptions thrown by the
+     * function must be ignored, and cancellation must be propagated upstream.
      */
     final class OnTerminate implements Inlet, Outlet {
         private final Runnable action;
@@ -539,13 +656,13 @@ public interface Stage {
     }
 
     /**
-     * A stage returning a stream containing all the elements from this stream,
-     * additionally performing the provided action when this stream completes.
+     * A stage returning a stream containing all the elements from this stream, additionally performing the provided
+     * action when this stream completes.
      * <p>
-     * The given action is called when the stream completes successfully. Use {@link OnError} to handle failures, and
-     * {@link OnTerminate} if the action needs to be called for both completion and error.
+     * The given action must be called when the stream completes successfully. Use {@link OnError} to handle failures,
+     * and {@link OnTerminate} if the action needs to be called for completion, error or cancellation.
      * <p>
-     * Any {@link RuntimeException} thrown by the function should be propagated down the stream as an error.
+     * Any {@link RuntimeException} thrown by this function must be propagated downstream as an error.
      */
     final class OnComplete implements Inlet, Outlet {
         private final Runnable action;
@@ -565,19 +682,19 @@ public interface Stage {
     }
 
     /**
-     * A stage to handle error from upstream. It builds a stream containing all the elements from  upstream. Additionally,
-     * in the case of failure, rather than invoking {@link Subscriber#onError(Throwable)}, it invokes a given method and
-     * emits the result as final event of the stream.
-     *
-     * By default, when a stream encounters an error that prevents it from emitting the expected item to its subscriber,
-     * the stream (publisher) invokes its subscriber's <code>onError</code> method, and then terminate without invoking
-     * any more of its subscriber's methods. This operator changes this behavior. If the current stream encounters an
-     * error, instead of invoking its subscriber's <code>onError</code> method, it will instead emit the return value of
-     * the passed function. This operator prevents errors from propagating or to supply fallback data should errors be
-     * encountered.
-     *
-     * Any {@link RuntimeException} thrown by the function should be propagated down the stream as an error.
-     *
+     * A stage to handle errors from upstream. It builds a stream containing all the elements from upstream.
+     * Additionally, in the case of failure, rather than propagating the error downstream, it invokes the given
+     * function method emits the result as the final event of the stream, terminating the stream after that.
+     * <p>
+     * By default, when a stream encounters an error that prevents it from emitting the expected item to its
+     * subscriber, the stream (publisher) invokes its subscriber's <code>onError</code> method, and then terminates
+     * without invoking any more of its subscriber's methods. This operator changes this behavior. If the current
+     * stream encounters an error, instead of invoking its subscriber's <code>onError</code> method, it will instead
+     * emit the return value of the passed function. This operator prevents errors from propagating and allows
+     * supplying fallback data should errors be encountered.
+     * <p>
+     * Any {@link RuntimeException} thrown by the function must be propagated downstream as an error, replacing the
+     * exception that the function was handling.
      */
     final class OnErrorResume implements Inlet, Outlet {
         private final Function<Throwable, ?> function;
@@ -598,20 +715,24 @@ public interface Stage {
     }
 
     /**
-     * A stage to handle error from upstream. It builds a stream containing all the elements from  upstream. Additionally,
-     * in the case of failure, rather than invoking {@link Subscriber#onError(Throwable)}, it invokes a given method and
-     * switch the control to the returned stream.
-     *
-     * By default, when a stream encounters an error that prevents it from emitting the expected item to its subscriber,
-     * the stream (publisher) invokes its subscriber's <code>onError</code> method, and then terminate without invoking
-     * any more of its subscriber's methods. This operator changes this behavior. If the current stream encounters an
-     * error, instead of invoking its subscriber's <code>onError</code> method, it will instead relinquish control to the
-     * {@link org.eclipse.microprofile.reactive.streams.PublisherBuilder} returned from given function, which invoke the
-     * subscriber's <code>onNext</code> method if it is able to do so. In such a case, because no publisher necessarily
-     * invokes <code>onError</code>, the subscriber may never know that an error happened.
-     *
-     * Any {@link RuntimeException} thrown by the function should be propagated down the stream as an error.
-     *
+     * A stage to handle errors from upstream. It builds a stream containing all the elements from upstream.
+     * Additionally, in the case of failure, rather than propagating the error downstream, it invokes the given
+     * function and switches control to the returned stream.
+     * <p>
+     * By default, when a stream encounters an error that prevents it from emitting the expected item to its
+     * subscriber, the stream (publisher) invokes its subscriber's <code>onError</code> method, and then terminates
+     * without invoking any more of its subscriber's methods. This operator changes this behavior. If the current
+     * stream encounters an error, instead of invoking its subscriber's <code>onError</code> method, it will instead
+     * relinquish control to the {@link org.eclipse.microprofile.reactive.streams.PublisherBuilder} returned from
+     * given function. In such a case, because no publisher necessarily invokes <code>onError</code>, the subscriber
+     * may never know that an error happened.
+     * <p>
+     * Any elements emitted by the returned publisher must be sent downstream, in addition to its completion and error
+     * signals. If the returned publisher completes with an error, that error must not result in the recovery function
+     * on this stage being invoked again.
+     * <p>
+     * Any {@link RuntimeException} thrown by the function must be propagated downstream as an error, replacing the
+     * exception that the function was handling.
      */
     final class OnErrorResumeWith implements Inlet, Outlet {
         private final Function<Throwable, Graph> function;
@@ -634,7 +755,7 @@ public interface Stage {
     /**
      * A failed publisher.
      * <p>
-     * When built, this should produce a publisher that immediately fails the stream with the passed in error.
+     * When built, this must produce a publisher that immediately fails the stream with the passed in error.
      */
     final class Failed implements Outlet {
         private final Throwable error;
@@ -655,11 +776,11 @@ public interface Stage {
      * <p>
      * The resulting publisher produced by the concat stage must emit all the elements from the first graph,
      * and once that graph emits a completion signal, it must then subscribe to and emit all the elements from
-     * the second. If an error is emitted by the either graph, the error should be emitted from the resulting stream.
+     * the second. If an error is emitted by the either graph, the error must be emitted from the resulting stream.
      * <p>
      * If processing terminates early while the first graph is still emitting, either due to that graph emitting an
      * error, or due to a cancellation signal from downstream, then the second graph must be subscribed to and cancelled.
-     * This is to ensure that any hot publishers that may be backing the graphs are cleaned up.
+     * This is to ensure that any hot publishers holding onto resources that may be backing the graphs are cleaned up.
      */
     final class Concat implements Outlet {
         private final Graph first;
@@ -687,7 +808,19 @@ public interface Stage {
         }
     }
 
+    /**
+     * A cancelling stage.
+     * <p>
+     * This stage immediately cancels upstream when it is started.
+     * <p>
+     * The {@link CompletionStage} produced by this stage must also be redeemed immediately with {@code null}.
+     */
     final class Cancel implements Inlet {
+
+        /**
+         * The singleton instance of the cancel stage. Implementations may use reference equality to test for this
+         * stage.
+         */
         public static final Cancel INSTANCE = new Cancel();
 
         private Cancel() {

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -48,8 +48,6 @@ It is the intention that once incubated in MicroProfile, this specification will
 
 This specification aims to define a set of operators to manipulate Reactive Streams. The proposed API is voluntarily close to the `java.utils.Stream` API.
 
-It does not define CDI and container API integrations but implementations may provide integrations.
-
 === Reactive Streams API dependency
 
 Reactive Streams has been included in the JDK9 as the `java.util.concurrent.Flow` API, which contains the `Publisher`, `Subscriber`, `Subscription` and `Processor` interfaces as nested interfaces of `Flow`.
@@ -67,83 +65,3 @@ To facilitate an eventual migration to the JDK9 interfaces, once MicroProfile ad
 For example, `getSubscriber` will be called `getRsSubscriber`.
 This will allow new methods to be added in future that return `java.util.concurrent.Flow` interfaces, without the `Rs` in the name, allowing the existing `Rs` methods to be kept for a limited time for backwards compatibility.
 Methods that accept a `org.reactivestreams` interface do not need to be given the same treatment, as support for the JDK9 interfaces can be added by overloading them, with backwards compatibility being maintained (see https://github.com/eclipse/microprofile-reactive/blob/master/approach.asciidoc[reactive approach for MicroProfile]).
-
-== Design
-
-The design of MicroProfile Reactive Streams is centered around **builders** for the various shapes of streams.
-Each builder contains zero or more stages. There are three different shapes of stages:
-
-* Publisher. A publisher stage has an outlet, but no inlet.
-
-image::images/publisher-stage.svg[Publisher stage,width=200,align="center"]
-
-* Processor. A processor stage has an inlet and an outlet.
-
-image::images/processor-stage.svg[Processor stage,width=250,align="center"]
-
-* Subscriber. A subscriber stage has an inlet, but no outlet.
-
-image::images/subscriber-stage.svg[Subscriber stage,width=180,align="center"]
-
-Stream stages can be built into graphs, using the builders. There are four different shapes of graphs that can be built:
-
-* Publishers. A publisher has one outlet but no inlet, and is represented as a Reactive Streams `Publisher` when built.
-It contains one publisher stage, followed by zero or more processor stages. This is called a `PublisherBuilder`
-
-image::images/publisher-builder.svg[Publisher,width=320,align="center"]
-
-* Processors. A processor has one inlet and one outlet, and is represented as a Reactive Streams `Processor` when built.
-It contains zero or more processor stages. This is called a `ProcessorBuilder`.
-
-image::images/processor-builder.svg[Processor,width=350,align="center"]
-
-* Subscribers. A subscriber has one inlet but no outlet, and it also has a result.
-It is represented as a product of a Reactive Streams `Subscriber` and a `CompletionStage` that is redeemed with the result, or error if the stream fails, when built.
-It contains zero or more processor stages, followed by a single subscriber stage. This is called a `SubscriberBuilder`.
-
-image::images/subscriber-builder.svg[Subscriber,width=300,align="center"]
-
-* Closed graphs. A closed graph has no inlet or outlet, both having being provided in during the construction of the graph.
-It is represented as a `CompletionStage` of the result of the stream.
-It contains a publisher stage, followed by zero or more processor stages, followed by a subscriber stage.
-This is called a `CompletionRunner`. The result is retrieved using the `run` method.
-
-image::images/closed-graph-builder.svg[Closed graph,width=420,align="center"]
-
-While building a stream, the stream may change shape during its construction.
-For example, a publisher may be collected into a `List` of elements.
-When this happens, the stream becomes a closed graph, since there is no longer an outlet, but just a result, the result being the `List` of elements:
-
-Here's an example of a more complex situation where a `PublisherBuilder` is plumbed to a `SubscriberBuilder`, producing a `CompletionRunner`:
-
-[source, java]
-----
-PublisherBuilder<Integer> evenIntsPublisher =
-  ReactiveStreams.of(1, 2, 3, 4)
-    .filter(i -> i % 2 == 0); <1>
-
-SubscriberBuilder<Integer, List<Integer>> doublingSubscriber =
-  ReactiveStreams.<Integer>builder()
-    .map(i -> i = i * 2)
-    .toList(); <2>
-
-CompletionRunner<List<Integer>> result =
-  eventIntsPublisher.to(doublingSubscriber); <3>
-----
-<1> A publisher of integers 2 and 4.
-<2> A subscriber that first doubles integers, then collects into a list.
-<3> A closed graph that when run, will produce the result in a `CompletionStage`.
-
-image::images/change-shape.svg[Combining two graphs,width=600,align="center"]
-
-When MicroProfile specifications provide an API that uses Reactive Streams, it is intended that application developers can return and pass the builder interfaces directly to the MicroProfile APIs.
-In many cases, application developers will not need to run the streams themselves.
-However, should they need to run the streams directly themselves, they can do so by using the streams `build` or `run`
-methods. `PublisherBuilder`, `SubscriberBuilder` and `ProcessorBuilder` all provide a `build` method that returns a
-`Publisher`, `CompletionSubscriber` and `Processor` respectively, while `CompletionRunner`, since it actually
-runs the stream, provides a `run` method that returns a `CompletionStage`.
-
-The `CompletionSubscriber` class is so named because, where a `CompletionStage` is a stage of asynchronous computation that completes with a value or an error, a `CompletionSubscriber` is subscriber to an asynchronous stream that completes with a value or an error.
-
-The `build` and `run` methods both provide a zero arg variant, which uses the default Reactive Streams engine provided by the platform, as well as a overload that takes a `ReactiveStreamsEngine`, allowing application developers to use a custom engine when they please.
-

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[reactivestreamscdi]]
+== CDI Integration
+
+MicroProfile Reactive Streams Operators implementations may be used independently of a CDI container.
+Consequently, implementations are not required to provide any integration with CDI.
+
+This section of the specification is intended to provide advice for how other specifications may integrate CDI with MicroProfile Reactive Streams Operators.
+
+=== Injection of engines
+
+If a MicroProfile container provides an implementation of MicroProfile Reactive Streams Operators, then it must make an application scoped `ReactiveStreamsEngine` available for injection.
+
+=== Contexts
+
+This specification places no requirements on the propagation of CDI context, or what context(s) should be active when user supplied callbacks are executed during the running of a stream.
+
+Other specifications that use this specification may require that implementations make certain context's to be active when user callbacks are executed.
+In this case, it is expected that such specifications will have the responsibility of running the streams.
+
+For example, a hypothetical WebSocket specification may allow user code to return a `ProcessorBuilder` to handle messages:
+
+[source, java]
+----
+@WebSocket("/echo")
+public ProcessorBuilder<Message, Message> echoWebsocket() {
+  return ReactiveStreams.<Message>builder().map(message ->
+    new Message("Echoing " + message.getText())
+  );
+}
+----
+
+In this case, the implementation of that hypothetical WebSocket specification is responsible for running the `ProcessorBuilder` returned by the user, and that specification may require that the engine it uses to run it makes the request context active in callbacks, such as the `map` callback above.
+Since the implementation of that specification is in control of which engine is used to run the processor, this requirement can be made by that specification.
+It is the responsibility of that implementation (and the MicroProfile container that pulls these implementations together) to ensure that the MicroProfile Reactive Streams Operators implementation used is able to support CDI context propagation.
+
+In contrast, if a user is responsible for executing a stream, like in the following hypothetical example:
+
+[source, java]
+----
+@WebSocket("/echo")
+public void echoWebsocket(PublisherBuilder<Message> incoming,
+  SubscriberBuilder<Message, Void> outgoing) {
+
+  incoming.map(message ->
+    new Message("Echoing " + message.getText()
+  ).to(outgoing).run();
+}
+----
+
+Then there is no clear way for the container to control how the engine used there, which in this case would be loaded through the Java `ServiceLoader` API, would propagate context.
+For this reason, any cases where users are running their own streams are not expected to require any CDI context propagation, and it is recommended that specifications favour APIs where the container runs the stream, not the user, to facilitate context propagation.

--- a/spec/src/main/asciidoc/design.asciidoc
+++ b/spec/src/main/asciidoc/design.asciidoc
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[reactivestreamsdesign]]
+== Design
+
+The design of MicroProfile Reactive Streams Operators is centered around **builders** for the various shapes of streams.
+
+=== Stages
+
+Each builder contains zero or more stages. There are three different shapes of stages:
+
+* Publisher. A publisher stage has an outlet, but no inlet.
+
+image::images/publisher-stage.svg[Publisher stage,width=200,align="center"]
+
+* Processor. A processor stage has an inlet and an outlet.
+
+image::images/processor-stage.svg[Processor stage,width=250,align="center"]
+
+* Subscriber. A subscriber stage has an inlet, but no outlet.
+
+image::images/subscriber-stage.svg[Subscriber stage,width=180,align="center"]
+
+=== Graphs
+
+Stream stages can be built into graphs, using the builders. There are four different shapes of graphs that can be built:
+
+* Publishers. A publisher has one outlet but no inlet, and is represented as a Reactive Streams `Publisher` when built.
+It contains one publisher stage, followed by zero or more processor stages. This is called a `PublisherBuilder`
+
+image::images/publisher-builder.svg[Publisher,width=320,align="center"]
+
+* Processors. A processor has one inlet and one outlet, and is represented as a Reactive Streams `Processor` when built.
+It contains zero or more processor stages. This is called a `ProcessorBuilder`.
+
+image::images/processor-builder.svg[Processor,width=350,align="center"]
+
+* Subscribers. A subscriber has one inlet but no outlet, and it also has a result.
+It is represented as a product of a Reactive Streams `Subscriber` and a `CompletionStage` that is redeemed with the result, or error if the stream fails, when built.
+It contains zero or more processor stages, followed by a single subscriber stage. This is called a `SubscriberBuilder`.
+
+image::images/subscriber-builder.svg[Subscriber,width=300,align="center"]
+
+* Closed graphs. A closed graph has no inlet or outlet, both having being provided in during the construction of the graph.
+It is represented as a `CompletionStage` of the result of the stream.
+It contains a publisher stage, followed by zero or more processor stages, followed by a subscriber stage.
+This is called a `CompletionRunner`. The result is retrieved using the `run` method.
+
+image::images/closed-graph-builder.svg[Closed graph,width=420,align="center"]
+
+While building a stream, the stream may change shape during its construction.
+For example, a publisher may be collected into a `List` of elements.
+When this happens, the stream becomes a closed graph, since there is no longer an outlet, but just a result, the result being the `List` of elements:
+
+Here's an example of a more complex situation where a `PublisherBuilder` is plumbed to a `SubscriberBuilder`, producing a `CompletionRunner`:
+
+[source, java]
+----
+PublisherBuilder<Integer> evenIntsPublisher =
+  ReactiveStreams.of(1, 2, 3, 4)
+    .filter(i -> i % 2 == 0); <1>
+
+SubscriberBuilder<Integer, List<Integer>> doublingSubscriber =
+  ReactiveStreams.<Integer>builder()
+    .map(i -> i = i * 2)
+    .toList(); <2>
+
+CompletionRunner<List<Integer>> result =
+  eventIntsPublisher.to(doublingSubscriber); <3>
+----
+<1> A publisher of integers 2 and 4.
+<2> A subscriber that first doubles integers, then collects into a list.
+<3> A closed graph that when run, will produce the result in a `CompletionStage`.
+
+image::images/change-shape.svg[Combining two graphs,width=600,align="center"]
+
+=== Usage
+
+When MicroProfile specifications provide an API that uses Reactive Streams, it is intended that application developers can return and pass the builder interfaces directly to the MicroProfile APIs.
+In many cases, application developers will not need to run the streams themselves.
+However, should they need to run the streams directly themselves, they can do so by using the streams `build` or `run`
+methods. `PublisherBuilder`, `SubscriberBuilder` and `ProcessorBuilder` all provide a `build` method that returns a
+`Publisher`, `CompletionSubscriber` and `Processor` respectively, while `CompletionRunner`, since it actually
+runs the stream, provides a `run` method that returns a `CompletionStage`.
+
+The `CompletionSubscriber` class is so named because, where a `CompletionStage` is a stage of asynchronous computation that completes with a value or an error, a `CompletionSubscriber` is subscriber to an asynchronous stream that completes with a value or an error.
+
+The `build` and `run` methods both provide a zero arg variant, which uses the default Reactive Streams engine provided by the platform, as well as a overload that takes a `ReactiveStreamsEngine`, allowing application developers to use a custom engine when they please.

--- a/spec/src/main/asciidoc/implementation.asciidoc
+++ b/spec/src/main/asciidoc/implementation.asciidoc
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+[[reactivestreamsimplementation]]
+== Implementation
+
+The behavior of each stage is specified in the javadocs for stages in the SPI, and tested by the TCK.
+
+Generally, across all stages, the following requirements exist:
+
+=== Memory visibility
+
+Within a single stage in a single stream, implementations must guarantee a _happens-before_ relationship between any invocation of all callbacks supplied to that stage.
+
+Between different stages of a single stream, it is recommended that a _happens-before_ relationship exists between callbacks of different stages, however this is not required, and end users of the API must not depend on this.
+Implementations are expected to implement this for performance reasons, this is also known as operator fusing.
+Implementations may decide, for whatever reason, not to fuse stages in certain circumstances, when this is done, it is said that there is an asynchronous boundary between the two stages.
+
+When Reactive Streams interfaces, that is, `Publisher`, `Subscriber` or `Processor`, are wrapped in a stage, implementations may place an asynchronous boundary between that stage and its neighbors if they choose.
+Whether implementations do or don't place an asynchronous boundary there, they must conform to the Reactive Streams specification with regards to memory visibility.
+
+=== User exceptions
+
+Exceptions thrown by user supplied callbacks must be caught and propagated downstream, unless otherwise handled by an error handling stage.
+
+User exceptions must not be thrown by the `build` or `run` methods of the builders.
+For example, if a user supplies an `Iterable` as a source for a `PublisherBuilder`, and the `iterator()` method is invoked synchronously from the `build` method on the publisher, and it throws an exception, this exception must be caught, and propagated through the stream, not thrown from the `build` method.
+
+An exception to this is the callbacks provided in user supplied Reactive Streams, ie `Publisher`, `Subscriber` and `Processor`.
+Since these interfaces are specified not to throw any exceptions when the consumer is adhering to the spec, implementations may assume that these interfaces won't throw exceptions, and the behavior of an implementation should these interfaces throw exceptions is unspecified.
+
+In some cases, exceptions may be wrapped, for example, `CompletableFuture` wraps exceptions in a `CompletionException`.
+It is recommended that implementations do not wrap exceptions if they don't need to, but rather that they propagate them downstream as is.
+
+=== Error propagation
+
+Errors may be eagerly propagated by stages if an implementation chooses to do this.
+Such propagation can aid with fast failure of stages, to ensure things like connection failures do not wait excessively to discover that they have failed.
+
+A consequence of this is that errors can in certain circumstances overtake elements.
+For example, the `flatMapCompletionStage` stage may receive an error while an element is being asynchronously processed.
+This error may immediately be propagated downstream, which will mean the eventual redemption of the `CompletionStage` returned by the mapper function for the stage will be ignored, and the element it is redeemed with will be dropped.
+
+When a user does not desire this behavior, and wants to guarantee that stages don't drop elements when upstream errors arrive, they may insert an error recovery stage, such as `onErrorResume`, before the stage that they don't want to drop elements from.
+They will then need to implement an out of band mechanism to propagate the error, such as wrapping it in an element, should they wish to handle it downstream.
+
+=== Cleanup
+
+Implementations must assume that any `PublisherBuilder`, `SubscriberBuilder` or `ProcessorBuilder` supplied to them, or any stages within, potentially hold resources, and must be cleaned up when the stream shuts down.
+For example, a `concat` stage accepts two `PublisherBuilder`'s.
+If the stream is cancelled before the first is finished, the second must still be built, and then cancelled too.
+
+=== null elements
+
+Reactive Streams does not allow `null` elements. Hence, any user callbacks that return `null` as an element to be emitted by a stage must cause the stage to fail with a `NullPointerException`.

--- a/spec/src/main/asciidoc/microprofile-reactive-streams-operators-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-reactive-streams-operators-spec.asciidoc
@@ -35,6 +35,9 @@ include::license-alv2.asciidoc[]
 == MicroProfile Reactive Streams Operators
 
 include::architecture.asciidoc[]
+include::design.asciidoc[]
+include::implementation.asciidoc[]
+include::cdi.asciidoc[]
 
 include::examples.asciidoc[]
 

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/api/ReactiveStreamsVerification.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/api/ReactiveStreamsVerification.java
@@ -60,6 +60,11 @@ public class ReactiveStreamsVerification {
         assertEquals(getStage(Stage.Of.class, graph).getElements(), Collections.singletonList("foo"));
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void ofSingleNull() {
+        ReactiveStreams.of((Object) null);
+    }
+
     @Test
     public void ofVarArgs() {
         Graph graph = GraphAccessor.buildGraphFor(ReactiveStreams.of("a", "b", "c"));

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/spi/FlatMapCompletionStageVerification.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/spi/FlatMapCompletionStageVerification.java
@@ -157,6 +157,16 @@ public class FlatMapCompletionStageVerification extends AbstractStageVerificatio
         await(cancelled);
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void flatMapCsStageShouldFailIfNullIsReturned() {
+        CompletableFuture<Void> cancelled = new CompletableFuture<>();
+        CompletionStage<List<Object>> result = infiniteStream().onTerminate(() -> cancelled.complete(null))
+            .flatMapCompletionStage(t -> CompletableFuture.completedFuture(null))
+            .toList().run(getEngine());
+        await(cancelled);
+        await(result);
+    }
+
     @Test
     public void flatMapCsStageBuilderShouldBeResuable() {
         ProcessorBuilder<Integer, Integer> mapper = ReactiveStreams.<Integer>builder()

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/spi/FlatMapIterableStageVerification.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/spi/FlatMapIterableStageVerification.java
@@ -143,6 +143,36 @@ public class FlatMapIterableStageVerification extends AbstractStageVerification 
         assertEquals(await(ReactiveStreams.of(1, 2).via(mapper).toList().run(getEngine())), Arrays.asList(1, 1, 2, 2));
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void flatMapIterableStageShouldFailIfNullIterableReturned() {
+        CompletableFuture<Void> cancelled = new CompletableFuture<>();
+        CompletionStage<List<Object>> result = infiniteStream().onTerminate(() -> cancelled.complete(null))
+            .flatMapIterable(t -> null)
+            .toList().run(getEngine());
+        await(cancelled);
+        await(result);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void flatMapIterableStageShouldFailIfNullIteratorReturned() {
+        CompletableFuture<Void> cancelled = new CompletableFuture<>();
+        CompletionStage<List<Object>> result = infiniteStream().onTerminate(() -> cancelled.complete(null))
+            .flatMapIterable(t -> () -> null)
+            .toList().run(getEngine());
+        await(cancelled);
+        await(result);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void flatMapIterableStageShouldFailIfNullElementReturnedFromIterator() {
+        CompletableFuture<Void> cancelled = new CompletableFuture<>();
+        CompletionStage<List<Object>> result = infiniteStream().onTerminate(() -> cancelled.complete(null))
+            .flatMapIterable(t -> Collections.singletonList(null))
+            .toList().run(getEngine());
+        await(cancelled);
+        await(result);
+    }
+
     @Override
     List<Object> reactiveStreamsTckVerifiers() {
         return Collections.singletonList(new ProcessorVerification());

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/spi/MapStageVerification.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/spi/MapStageVerification.java
@@ -70,6 +70,16 @@ public class MapStageVerification extends AbstractStageVerification {
             .run(getEngine()));
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void mapStageShouldFailIfNullReturned() {
+        CompletableFuture<Void> cancelled = new CompletableFuture<>();
+        CompletionStage<List<Object>> result = infiniteStream().onTerminate(() -> cancelled.complete(null))
+            .map(t -> null)
+            .toList().run(getEngine());
+        await(cancelled);
+        await(result);
+    }
+
     @Test
     public void mapStageBuilderShouldBeReusable() {
         ProcessorBuilder<Integer, Integer> map = ReactiveStreams.<Integer>builder().map(i -> i + 1);

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/spi/OfStageVerification.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/streams/tck/spi/OfStageVerification.java
@@ -116,6 +116,11 @@ public class OfStageVerification extends AbstractStageVerification {
             .run(getEngine()));
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void ofStageShouldFailIfNullProduced() {
+        await(ReactiveStreams.fromIterable(Arrays.asList(null, null)).toList().run(getEngine()));
+    }
+
     @Test
     public void ofStageShouldBeReusable() {
         PublisherBuilder<Integer> publisher = ReactiveStreams.of(1, 2, 3);


### PR DESCRIPTION
* Split a design section out from the architecture section
* Added an implementation section for notes on how things should be implemented, includes requirements on how errors should be handled and propgated, memory visibility requirements, null handling requirements.
* Added a section on CDI. There is one requirement here, that is that if a MicroProfile container provides an implementation of this spec, it must make an engine available by injection. Additionally, added advice about how context may be specified by other specs.
* Filled out the javadocs for each stage to include all the requirements that the TCK tests for, so now they can be implemented without needing to run the TCK to learn out how things should be handled.
* Added a small number of TCK tests, testing for null elements emitted.  Since Reactive Streams expressly forbids null elements, any stage that attempts to emit null, for example, because the user returned null from a callback, must fail with an NPE.

@cescoffier Not sure how your impl will handle the null TCK tests, I'm not sure if rxjava is as strict as Reactive Streams requires. Let me know if you object to these tests. But, they were useful for me, I found a bug in the zerodep implementation where if a flatMapCompletionStage emitted a null, it would hang. Also, have a read over the requirements for error handling, and see if you agree.