### PR TITLE
Fixed links in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,11 +76,11 @@ The whole MicroProfile Reactive Streams project can be built via Apache Maven.
 
 The API documentation makes extensive use of marble diagrams to visualize what each operator does. These diagrams are generated using a DSL written specifically for this purpose, rather creating them in a visual diagram editor which would make it very difficult to ensure consistency, especially between different contributors.
 
-The DSL is implemented in JavaScript, and the diagrams are created using SVG. This combination of technologies allows rapid development of the diagrams, since they can be run, inspected, debugged and tweaked directly in a web browser. They are then exported to PNG files using [Puppeteer](https://developers.google.com/web/tools/puppeteer/), a high level JavaScript API for controlling headless Chrome, running on node.
+The DSL is implemented in JavaScript, and the diagrams are created using SVG. This combination of technologies allows rapid development of the diagrams, since they can be run, inspected, debugged and tweaked directly in a web browser. They are then exported to PNG files using https://developers.google.com/web/tools/puppeteer/[Puppeteer], a high level JavaScript API for controlling headless Chrome, running on node.
 
 === Editing diagrams
 
-All the diagrams are declared in [mp-rs-ops-marbles.js](api/src/docs/js/mp-rs-ops-marbles.js). This contains a map of all the graphs. Each graph has an array of stages, and stages have zero to many elements. The stages are as follows:
+All the diagrams are declared in link:api/src/docs/js/mp-rs-ops-marbles.js[`mp-rs-ops-marbles.js`]. This contains a map of all the graphs. Each graph has an array of stages, and stages have zero to many elements. The stages are as follows:
 
 * `ins` - An input stream. Called `ins` because `in` is a JavaScript keyword, and `ins` makes the width 3 characters for nice alignment with other stages. The first parameter may optionally be a map of options, the only option currently read is `label`, which is used to label the stage.
 * `sub` - A sub stream. This will automatically have a label generated for it, `stream[n]`, where `n` is the number of the sub stage, starting from one.
@@ -102,7 +102,7 @@ Each of the stages support zero to many marbles, which are declared as follows:
 
 After editing or creating a new diagram, you can test your changes by opening them in a browser. Before you do this on the very first time, you need to run `npm install` in the `api` module to ensure the JavaScript dependencies are installed. This will be done automatically if you run `mvn process-resources` (or any lifecycle phase after `process-resources`, such as `compile` or `install`) - the build uses the Maven frontend plugin to install Node, install npm, then run npm to install the dependencies. Included in the dependencies is an installation of Chromium which is used to generate the PNG diagrams for inclusion in the javadocs, this may take a while to download.
 
-Once the dependencies are installed, you can then open [`api/src/docs/js/index.html`](api/src/docs/js/index.html), this will show you all the rendered diagrams. No generation step is required to view these diagrams, you can simply hit refresh in the browser after making any changes.
+Once the dependencies are installed, you can then open link:api/src/docs/js/index.html[`api/src/docs/js/index.html`], this will show you all the rendered diagrams. No generation step is required to view these diagrams, you can simply hit refresh in the browser after making any changes.
 
 === Generating diagrams
 
@@ -124,4 +124,4 @@ Make sure to include the `alt` text, the CI build will fail if it's not there.
 
 You can then view the diagrams in the api docs by opening `api/target/apidocs/index.html`, and navigating to the class that you added the marble diagram to.
 
-Before committing your changes, make sure to use the above command to generate the diagrams, and then check the results of it into git, including the updated `marble-diagram-hashes.json` file. As part of the verification of the build, we have a task that checks that all the hashes of all the input and output files from the diagram generation process match the hashes when the diagrams were last generated. Failure to do this will result in the build failing in CI, and so it won't pass PR validation.
+Before committing your changes, make sure to use the above command to generate the diagrams, and then check the results of it into git, including the updated link:api/src/docs/js/marble-diagram-hashes.json[`marble-diagram-hashes.json`] file. As part of the verification of the build, we have a task that checks that all the hashes of all the input and output files from the diagram generation process match the hashes when the diagrams were last generated. Failure to do this will result in the build failing in CI, and so it won't pass PR validation.


### PR DESCRIPTION
There were a number of markdown style links which I've fixed to be valid asciidoc links.